### PR TITLE
README: add reference to specific unit system

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,9 @@
 This package reexports [Unitful.jl](https://github.com/ajkeller34/Unitful.jl) alongside two extra functions:
 
 1. `natural`, a function for converting a given quantity to the Physicist's so-called
-   "[natural units](https://en.wikipedia.org/wiki/Natural_units)", in which
+   "[natural units](https://en.wikipedia.org/wiki/Natural_units)", in particular the
+   [rationalized Planck units](https://en.wikipedia.org/wiki/Planck_units#Alternative_choices_of_normalization),
+   in which
  
    `ħ = c = ϵ₀ = kb = 1`
 


### PR DESCRIPTION
The "[natural units](https://en.wikipedia.org/wiki/Natural_units)" Wikipedia page describes multiple unit systems that bear this name, and although it mentions Planck units, it doesn't make a reference to its rationalized version.

This PR adds a [link to the latter](https://en.wikipedia.org/wiki/Planck_units#Alternative_choices_of_normalization) and the specific name to make the reference more explicit.