### PR TITLE
add dimless function for returning dimensionless quantities

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "NaturallyUnitful"
 uuid = "872cf16e-200e-11e9-2cdf-8bb39cfbec41"
-version = "1.0.0"
+version = "1.1.0"
 authors = ["MasonProtter <mason.protter@gmail.com>", "Lucas Gathercole <lucas.gathercole@gmail.com>"]
 
 [deps]

--- a/src/NaturallyUnitful.jl
+++ b/src/NaturallyUnitful.jl
@@ -1,6 +1,6 @@
 module NaturallyUnitful
 
-export natural, unitless, natdims, natdim, naturalunit
+export natural, dimless, unitless, natdims, natdim, naturalunit
 export NaturalSystem, PARTICLE_UNITS, QG_UNITS
 
 using Reexport

--- a/src/natural.jl
+++ b/src/natural.jl
@@ -67,6 +67,20 @@ end
 
 natural(q, units::Units...) = natural(q, DEFAULT_UNITS, units...)
 
+"""
+    dimless([T=Real], q, system::NaturalSystem=DEFAULT_UNITS)
+
+Convert a quantity `q` which is dimensionless in unit system `system` to type `T`, throwing
+an error if `q` is dimensionful.
+"""
+function dimless(::Type{T}, q, system::NaturalSystem=DEFAULT_UNITS)::T where {T}
+    # Unitful.jl can return non-T from T constructors!
+    # therefore the type assertion of the function return above is crucial
+    T(natural(q, system))
+end
+
+dimless(q, system::NaturalSystem=DEFAULT_UNITS) = dimless(Real, q, system)
+
 # For convenience when using custom unit systems
 (system::NaturalSystem)(q, units::Units...) = natural(q, system, units...)
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -19,4 +19,11 @@ using Test
     @test (@inferred natural(u"G"^(-1//2), QG_UNITS, u"μg")) ≈ 21.7u"μg" rtol = 0.05
 
     @inferred natural(u"kg^2 / m", PARTICLE_UNITS)
+
+    @test dimless(1u"c") ≈ 1
+    @test dimless(Float32, 1u"m/s") isa Float32
+    @test_throws MethodError dimless(1u"kg")
+
+    @inferred dimless(1u"c")
+    @inferred dimless(Float32, 0.1u"nC")
 end


### PR DESCRIPTION
This adds a new exported function (here called `dimless`, though I'm not attached to the name) which either successfully converts a dimensionless quantity to a (typically `Real`) number, or errors.  This is useful if e.g. you are setting up a problem and you want to get everything into `Float64` or `Float32`.

Ideally the error thrown would be something clear and dedicated like an `ArgumentError`, however there is some fishiness here because, annoyingly, Unitful.jl allows constructors of type `T` to return non-`T` objects.  Therefore here I am relying on a function return assertion which should be more reliable for type stability than inserting an extra assertion into the function body.  This makes having a dedicated error rather awkward, but I deemed it not worth adding additional complexity.